### PR TITLE
Comparing cards

### DIFF
--- a/lib/rubycards/card.rb
+++ b/lib/rubycards/card.rb
@@ -125,6 +125,10 @@ module RubyCards
       template.sub(/YY/, rank(true).ljust(2))
     end
 
+    def same_as?(card)
+      self.suit == card.suit && self.rank == card.rank
+    end
+
     private
 
     # Converts the string representation of a rank to an integer.

--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -10,10 +10,7 @@ module RubyCards
 
     def_delegators :cards, :empty?, :[], :shift
 
-    def draw
-      card = @cards.shift
-      Card.new(2)
-    end
+    alias :draw :shift
 
     RANKS = [*2..10, 'Jack', 'Queen', 'King', 'Ace']
     SUITS = %w{ Clubs Diamonds Hearts Spades }

--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -10,7 +10,10 @@ module RubyCards
 
     def_delegators :cards, :empty?, :[], :shift
 
-    alias :draw :shift
+    def draw
+      card = @cards.shift
+      Card.new(2)
+    end
 
     RANKS = [*2..10, 'Jack', 'Queen', 'King', 'Ace']
     SUITS = %w{ Clubs Diamonds Hearts Spades }

--- a/spec/rubycards/card_spec.rb
+++ b/spec/rubycards/card_spec.rb
@@ -126,4 +126,24 @@ describe Card do
     end
   end
 
+  describe "#same_as?" do
+    it "should return true when the two different cards with the same suit/rank match" do
+      deck1 = Deck.new
+      deck2 = Deck.new
+      deck1.cards.each_with_index do |_, index|
+        deck1[index].same_as?(deck2[index]).should == true
+        deck2[index].same_as?(deck1[index]).should == true
+      end
+    end
+
+    it "should return false when compared to different cards" do
+      deck1 = Deck.new
+      deck2 = Deck.new
+      deck1.cards.each_with_index do |_, index|
+        deck1[index].same_as?(deck2[index-1]).should == false
+        deck2[index].same_as?(deck1[index-1]).should == false
+      end
+    end
+  end
+
 end

--- a/spec/rubycards/deck_spec.rb
+++ b/spec/rubycards/deck_spec.rb
@@ -31,7 +31,7 @@ describe Deck do
     it 'draws a single card from the deck' do
       first_card = deck.cards.first
       cards_expected_after_draw = deck.cards[1..-1]
-      deck.draw.should == first_card
+      deck.draw.to_s.should == first_card.to_s
       deck.cards.should == cards_expected_after_draw
     end
   end

--- a/spec/rubycards/deck_spec.rb
+++ b/spec/rubycards/deck_spec.rb
@@ -31,7 +31,7 @@ describe Deck do
     it 'draws a single card from the deck' do
       first_card = deck.cards.first
       cards_expected_after_draw = deck.cards[1..-1]
-      deck.draw.to_s.should == first_card.to_s
+      deck.draw.same_as?(first_card).should == true
       deck.cards.should == cards_expected_after_draw
     end
   end


### PR DESCRIPTION
When I was trying to implement one of my other pull requests with TDD, I noticed that I wasn't getting the :red_circle: on a test that I **knew** had to be failing.  The two cards were not the same, so why were they :green_apple: ??

I found that the reason was the <=> comparison override.  It was changed to be suit-agnostic, which is fine when measuring the value of cards, but... this is death when verifying cards are what they are.

I poked around and ended up writing a "same_as?" method for comparing cards.
