### PR TITLE
Shuffle tests

### DIFF
--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -30,7 +30,7 @@ module RubyCards
     #
     # @return [Deck] The shuffled deck
     def shuffle!
-      @cards.shuffle!
+      @cards = nil
       self
     end
 

--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -30,7 +30,7 @@ module RubyCards
     #
     # @return [Deck] The shuffled deck
     def shuffle!
-      @cards = nil
+      @cards.shuffle!
       self
     end
 

--- a/spec/rubycards/deck_spec.rb
+++ b/spec/rubycards/deck_spec.rb
@@ -22,6 +22,12 @@ describe Deck do
       deck.cards.should_not == cards_before_shuffling
     end
 
+    it "should should shuffle the internal cards array" do
+      cards_before_shuffling = deck.cards.dup
+      expect(deck.instance_variable_get("@cards")).to receive(:shuffle!)
+      deck.shuffle!
+    end
+
     it 'returns itself' do
       should == deck.shuffle!
     end


### PR DESCRIPTION
I added a test to verify that the cards were shuffled using the shuffle method.

I know, I know, some people don't like mocking in tests like this, but I've found that it's the easiest way to test behaviors that are tied to any sort of randomization -- especially when the randomization is done deep in the language or framework.  

This production code change demonstrates the problem with **not** using the mock.  I changed `shuffle!` to delete all of the cards and the tests still passed, as they weren't actually testing that the shuffle was occuring:  https://github.com/darrencauthon/rubycards/commit/f265ca4e4cd90d0c38cd89613dd2ad68e8316c05#diff-d145fa3fd23d3dc189ba7fa0ef16a3f8R33
