### PR TITLE
Feature: Add ability to exclude rank(s) and support multiple decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ puts hand
 
 Which produces the image at the top of this README.
 
+Here's a second example showing 2 decks, with the 2 and Jacks removed, shuffling, and drawing 10 cards into a hand:
+
+```ruby
+require 'rubycards'
+include RubyCards
+
+hand = Hand.new
+deck = Deck.new(number_decks: 2, exclude_rank: [2, 'Jack'])
+
+deck.shuffle!
+
+hand.draw(deck, 10)
+
+puts hand
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -16,12 +16,17 @@ module RubyCards
     SUITS = %w{ Clubs Diamonds Hearts Spades }
 
     # Initializes a standard deck of 52 cards
+    # options:
+    #   :exclude_rank
+    #     eg. Deck.new(exclude_rank: [2,'Jack'])
+    #     will excludes the 8 cards of the 2 and Jack rank
     #
     # @return [Deck] A standard deck of cards
-    def initialize
+    def initialize(options={})
       @cards = []
+      options[:exclude_rank] ||= []
 
-      RANKS.product(SUITS).each do |rank, suit|
+      (RANKS - options[:exclude_rank]).product(SUITS).each do |rank, suit|
         @cards << Card.new(rank, suit)
       end
     end

--- a/lib/rubycards/deck.rb
+++ b/lib/rubycards/deck.rb
@@ -17,17 +17,23 @@ module RubyCards
 
     # Initializes a standard deck of 52 cards
     # options:
+    #   :number_decks
+    #     eg. Deck.new(number_decks: 2)
+    #     will create 2 decks standard decks of 52
     #   :exclude_rank
     #     eg. Deck.new(exclude_rank: [2,'Jack'])
-    #     will excludes the 8 cards of the 2 and Jack rank
+    #     will exclude 8 cards of the 2 and Jack rank
     #
     # @return [Deck] A standard deck of cards
     def initialize(options={})
       @cards = []
       options[:exclude_rank] ||= []
+      options[:number_decks] ||= 1
 
-      (RANKS - options[:exclude_rank]).product(SUITS).each do |rank, suit|
-        @cards << Card.new(rank, suit)
+      options[:number_decks].times do
+        (RANKS - options[:exclude_rank]).product(SUITS).each do |rank, suit|
+          @cards << Card.new(rank, suit)
+        end
       end
     end
 

--- a/spec/rubycards/deck_spec.rb
+++ b/spec/rubycards/deck_spec.rb
@@ -155,4 +155,16 @@ describe Deck do
       end
     end
   end
+
+  context 'multiple_decks' do
+    let (:deck_2_decks) { Deck.new(number_decks: 2) }
+    it('initializes 104 cards') { expect(deck_2_decks.cards.count).to eq 104 }
+    it('unique of decks should be 52') {expect(deck_2_decks.cards.map(&:short).uniq.count).to eq 52}
+  end
+
+  context 'multiple_decks and excluded cards' do
+    let (:deck_2_decks_excluding_2) { Deck.new(number_decks: 2, exclude_rank: [5, 'Jack']) }
+    it('initializes 96 cards') { expect(deck_2_decks_excluding_2.cards.count).to eq 88 }
+    it('unique of decks should be 48') {expect(deck_2_decks_excluding_2.cards.map(&:short).uniq.count).to eq 44}
+  end
 end

--- a/spec/rubycards/deck_spec.rb
+++ b/spec/rubycards/deck_spec.rb
@@ -126,4 +126,33 @@ describe Deck do
       end
     end
   end
+
+  describe 'excluded cards' do
+    let (:deck_excluding_1) { Deck.new(exclude_rank: [5]) }
+    let (:deck_excluding_2) { Deck.new(exclude_rank: [5,7]) }
+    let (:deck_excluding_3) { Deck.new(exclude_rank: [5, 'Jack', 'Ace']) }
+
+    describe '#initialize' do
+      # Remove one card rank from deck
+      it('initializes 48 cards') { expect(deck_excluding_1.cards.count).to eq 48 }
+      it "doesn't include the excluded_rank in deck" do
+        expect(deck_excluding_1.map(&:to_i)).not_to include(5)
+        expect(deck_excluding_1.cards.count).to eq 48
+
+      end
+      # Remove two card ranks from deck
+      it('initializes 44 cards') { expect(deck_excluding_2.cards.count).to eq 44 }
+      it "doesn't include the excluded_rank in deck" do
+        expect(deck_excluding_2.map(&:to_i)).not_to include(5)
+        expect(deck_excluding_2.map(&:to_i)).not_to include(7)
+      end
+      # Remove three card ranks from deck, including 2 picture cards
+      it('initializes 40 cards') { expect(deck_excluding_3.cards.count).to eq 40 }
+      it "doesn't include the excluded_rank in deck" do
+        expect(deck_excluding_3.map(&:to_i)).not_to include(5)
+        expect(deck_excluding_3.map(&:to_i)).not_to include(11)
+        expect(deck_excluding_3.map(&:to_i)).not_to include(14)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some card games require more than the one deck to play and some games require the removal of some cards ranks.  Of course there can also be the combination of both.
